### PR TITLE
Allow for dynamic thread merging on IOS for embedded view mutations

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -34,10 +34,11 @@ std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,
-    bool instrumentation_enabled) {
-  return std::make_unique<ScopedFrame>(*this, gr_context, canvas, view_embedder,
-                                       root_surface_transformation,
-                                       instrumentation_enabled);
+    bool instrumentation_enabled,
+    fml::RefPtr<fml::TaskRunnerMerger> task_runner_merger) {
+  return std::make_unique<ScopedFrame>(
+      *this, gr_context, canvas, view_embedder, root_surface_transformation,
+      instrumentation_enabled, task_runner_merger);
 }
 
 CompositorContext::ScopedFrame::ScopedFrame(
@@ -46,13 +47,15 @@ CompositorContext::ScopedFrame::ScopedFrame(
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,
-    bool instrumentation_enabled)
+    bool instrumentation_enabled,
+    fml::RefPtr<fml::TaskRunnerMerger> task_runner_merger)
     : context_(context),
       gr_context_(gr_context),
       canvas_(canvas),
       view_embedder_(view_embedder),
       root_surface_transformation_(root_surface_transformation),
-      instrumentation_enabled_(instrumentation_enabled) {
+      instrumentation_enabled_(instrumentation_enabled),
+      task_runner_merger_(task_runner_merger) {
   context_.BeginFrame(*this, instrumentation_enabled_);
 }
 
@@ -64,6 +67,9 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
     flutter::LayerTree& layer_tree,
     bool ignore_raster_cache) {
   layer_tree.Preroll(*this, ignore_raster_cache);
+  if (MergeTaskRunnersForEmbeddedViews()) {
+    return RasterStatus::kResubmit;
+  }
   // Clearing canvas after preroll reduces one render target switch when preroll
   // paints some raster cache.
   if (canvas()) {
@@ -71,6 +77,25 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   }
   layer_tree.Paint(*this, ignore_raster_cache);
   return RasterStatus::kSuccess;
+}
+
+const int CompositorContext::ScopedFrame::kDefaultMergedLeaseDuration;
+
+bool CompositorContext::ScopedFrame::MergeTaskRunnersForEmbeddedViews() {
+  if (view_embedder_ && task_runner_merger_) {
+    const bool uiviews_mutated = view_embedder_->HasPendingViewOperations();
+    if (uiviews_mutated) {
+      bool are_merged = task_runner_merger_->AreMerged();
+      if (are_merged) {
+        task_runner_merger_->ExtendLease(kDefaultMergedLeaseDuration);
+      } else {
+        view_embedder_->CancelFrame();
+        task_runner_merger_->MergeWithLease(kDefaultMergedLeaseDuration);
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 void CompositorContext::OnGrContextCreated() {

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -13,6 +13,7 @@
 #include "flutter/flow/raster_cache.h"
 #include "flutter/flow/texture.h"
 #include "flutter/fml/macros.h"
+#include "flutter/fml/task_runner_merger.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 
@@ -20,7 +21,7 @@ namespace flutter {
 
 class LayerTree;
 
-enum class RasterStatus { kSuccess, kFailed };
+enum class RasterStatus { kSuccess, kResubmit, kFailed };
 
 class CompositorContext {
  public:
@@ -31,7 +32,8 @@ class CompositorContext {
                 SkCanvas* canvas,
                 ExternalViewEmbedder* view_embedder,
                 const SkMatrix& root_surface_transformation,
-                bool instrumentation_enabled);
+                bool instrumentation_enabled,
+                fml::RefPtr<fml::TaskRunnerMerger> task_runner_merger);
 
     virtual ~ScopedFrame();
 
@@ -57,6 +59,18 @@ class CompositorContext {
     ExternalViewEmbedder* view_embedder_;
     const SkMatrix& root_surface_transformation_;
     const bool instrumentation_enabled_;
+    fml::RefPtr<fml::TaskRunnerMerger> task_runner_merger_;
+
+    // This is the number of frames the task runners will stay
+    // merged after a frame where we see a mutation to the embedded views.
+    static const int kDefaultMergedLeaseDuration = 10;
+
+    // Returns true if this frame needs to be resubmitted.
+    // Will merge the task runners if there have been any mutations to the
+    // embedded views and our current thread configuration doesn't allow them.
+    // Extends lease on the merged threads if there has been a mutation in the
+    // current frame.
+    bool MergeTaskRunnersForEmbeddedViews();
 
     FML_DISALLOW_COPY_AND_ASSIGN(ScopedFrame);
   };
@@ -70,7 +84,8 @@ class CompositorContext {
       SkCanvas* canvas,
       ExternalViewEmbedder* view_embedder,
       const SkMatrix& root_surface_transformation,
-      bool instrumentation_enabled);
+      bool instrumentation_enabled,
+      fml::RefPtr<fml::TaskRunnerMerger> task_runner_merger);
 
   void OnGrContextCreated();
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -21,7 +21,7 @@ namespace flutter {
 
 class LayerTree;
 
-enum class RasterStatus { kSuccess, kResubmit, kFailed };
+enum class RasterStatus { kSuccess, kResubmit, kEnqueuePipeline, kFailed };
 
 class CompositorContext {
  public:

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -212,6 +212,7 @@ executable("fml_unittests") {
     "synchronization/semaphore_unittest.cc",
     "synchronization/thread_annotations_unittest.cc",
     "synchronization/waitable_event_unittest.cc",
+    "task_runner_merger_unittests.cc",
     "thread_local_unittests.cc",
     "thread_unittests.cc",
     "time/time_delta_unittest.cc",

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -64,6 +64,8 @@ source_set("fml") {
     "synchronization/waitable_event.h",
     "task_runner.cc",
     "task_runner.h",
+    "task_runner_merger.cc",
+    "task_runner_merger.h",
     "thread.cc",
     "thread.h",
     "thread_local.cc",

--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -79,4 +79,12 @@ void MessageLoop::SwapTaskQueues(MessageLoop* other) {
   loop_->SwapTaskQueues(other->loop_);
 }
 
+TaskQueueId MessageLoop::GetCurrentTaskQueueId() {
+  auto* loop = tls_message_loop.get();
+  FML_CHECK(loop != nullptr)
+      << "MessageLoop::EnsureInitializedForCurrentThread was not called on "
+         "this thread prior to message loop use.";
+  return loop->GetLoopImpl()->GetTaskQueueId();
+}
+
 }  // namespace fml

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -44,6 +44,7 @@ class MessageLoop {
 
  private:
   friend class TaskRunner;
+  friend class TaskRunnerMerger;
   friend class MessageLoopImpl;
 
   fml::RefPtr<MessageLoopImpl> loop_;

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -42,9 +42,10 @@ class MessageLoop {
 
   ~MessageLoop();
 
+  static TaskQueueId GetCurrentTaskQueueId();
+
  private:
   friend class TaskRunner;
-  friend class TaskRunnerMerger;
   friend class MessageLoopImpl;
 
   fml::RefPtr<MessageLoopImpl> loop_;

--- a/fml/message_loop_task_queues.cc
+++ b/fml/message_loop_task_queues.cc
@@ -237,7 +237,7 @@ bool MessageLoopTaskQueues::Unmerge(TaskQueueId owner) {
 
 bool MessageLoopTaskQueues::Owns(TaskQueueId owner, TaskQueueId subsumed) {
   MergedQueuesRunner merged_observers = MergedQueuesRunner(this, owner);
-  return subsumed == owner_to_subsumed_[owner];
+  return subsumed == owner_to_subsumed_[owner] || owner == subsumed;
 }
 
 // Subsumed queues will never have pending tasks.

--- a/fml/task_runner.cc
+++ b/fml/task_runner.cc
@@ -11,6 +11,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/message_loop_impl.h"
+#include "flutter/fml/message_loop_task_queues.h"
 
 namespace fml {
 
@@ -41,9 +42,24 @@ bool TaskRunner::RunsTasksOnCurrentThread() {
   if (!fml::MessageLoop::IsInitializedForCurrentThread()) {
     return false;
   }
-  const auto current_loop_id =
+
+  const auto current_queue_id =
       MessageLoop::GetCurrent().GetLoopImpl()->GetTaskQueueId();
-  return current_loop_id == loop_->GetTaskQueueId();
+  const auto loop_queue_id = loop_->GetTaskQueueId();
+
+  if (current_queue_id == loop_queue_id) {
+    return true;
+  }
+
+  auto queues = MessageLoopTaskQueues::GetInstance();
+  if (queues->Owns(current_queue_id, loop_queue_id)) {
+    return true;
+  }
+  if (queues->Owns(loop_queue_id, current_queue_id)) {
+    return true;
+  }
+
+  return false;
 }
 
 void TaskRunner::RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,

--- a/fml/task_runner.cc
+++ b/fml/task_runner.cc
@@ -43,8 +43,7 @@ bool TaskRunner::RunsTasksOnCurrentThread() {
     return false;
   }
 
-  const auto current_queue_id =
-      MessageLoop::GetCurrent().GetLoopImpl()->GetTaskQueueId();
+  const auto current_queue_id = MessageLoop::GetCurrentTaskQueueId();
   const auto loop_queue_id = loop_->GetTaskQueueId();
 
   if (current_queue_id == loop_queue_id) {

--- a/fml/task_runner_merger.cc
+++ b/fml/task_runner_merger.cc
@@ -1,0 +1,71 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define FML_USED_ON_EMBEDDER
+
+#include "flutter/fml/task_runner_merger.h"
+#include "flutter/fml/message_loop_impl.h"
+
+namespace fml {
+
+const int TaskRunnerMerger::kLeaseNotSet = -1;
+
+TaskRunnerMerger::TaskRunnerMerger(fml::TaskQueueId platform_queue_id,
+                                   fml::TaskQueueId gpu_queue_id)
+    : platform_queue_id_(platform_queue_id),
+      gpu_queue_id_(gpu_queue_id),
+      task_queues_(fml::MessageLoopTaskQueues::GetInstance()),
+      lease_term_(kLeaseNotSet) {
+  is_merged_ = task_queues_->Owns(platform_queue_id_, gpu_queue_id_);
+}
+
+void TaskRunnerMerger::MergeWithLease(size_t lease_term) {
+  FML_DCHECK(lease_term > 0) << "lease_term should be positive.";
+  if (!is_merged_) {
+    is_merged_ = task_queues_->Merge(platform_queue_id_, gpu_queue_id_);
+    lease_term_ = lease_term;
+  }
+}
+
+bool TaskRunnerMerger::OnWrongThread() {
+  const auto current_queue_id =
+      MessageLoop::GetCurrent().GetLoopImpl()->GetTaskQueueId();
+  if (is_merged_) {
+    return current_queue_id != platform_queue_id_;
+  } else {
+    return current_queue_id != gpu_queue_id_;
+  }
+}
+
+void TaskRunnerMerger::ExtendLease(size_t lease_term) {
+  FML_DCHECK(lease_term > 0) << "lease_term should be positive.";
+  if (lease_term_ != kLeaseNotSet && (int)lease_term > lease_term_) {
+    lease_term_ = lease_term;
+  }
+}
+
+bool TaskRunnerMerger::AreMerged() const {
+  return is_merged_;
+}
+
+void TaskRunnerMerger::DecrementLease() {
+  if (!is_merged_) {
+    return;
+  }
+
+  // we haven't been set to merge.
+  if (lease_term_ == kLeaseNotSet) {
+    return;
+  }
+
+  FML_DCHECK(lease_term_ > 0)
+      << "lease_term should always be positive when merged.";
+  lease_term_--;
+  if (lease_term_ == 0) {
+    bool success = task_queues_->Unmerge(platform_queue_id_);
+    is_merged_ = !success;
+  }
+}
+
+}  // namespace fml

--- a/fml/task_runner_merger.cc
+++ b/fml/task_runner_merger.cc
@@ -48,14 +48,14 @@ bool TaskRunnerMerger::AreMerged() const {
   return is_merged_;
 }
 
-void TaskRunnerMerger::DecrementLease() {
+bool TaskRunnerMerger::DecrementLease() {
   if (!is_merged_) {
-    return;
+    return false;
   }
 
   // we haven't been set to merge.
   if (lease_term_ == kLeaseNotSet) {
-    return;
+    return false;
   }
 
   FML_DCHECK(lease_term_ > 0)
@@ -64,7 +64,10 @@ void TaskRunnerMerger::DecrementLease() {
   if (lease_term_ == 0) {
     bool success = task_queues_->Unmerge(platform_queue_id_);
     is_merged_ = !success;
+    return true;
   }
+
+  return false;
 }
 
 }  // namespace fml

--- a/fml/task_runner_merger.cc
+++ b/fml/task_runner_merger.cc
@@ -29,8 +29,7 @@ void TaskRunnerMerger::MergeWithLease(size_t lease_term) {
 }
 
 bool TaskRunnerMerger::OnWrongThread() {
-  const auto current_queue_id =
-      MessageLoop::GetCurrent().GetLoopImpl()->GetTaskQueueId();
+  const auto current_queue_id = MessageLoop::GetCurrentTaskQueueId();
   if (is_merged_) {
     return current_queue_id != platform_queue_id_;
   } else {

--- a/fml/task_runner_merger.h
+++ b/fml/task_runner_merger.h
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FML_SHELL_COMMON_TASK_RUNNER_MERGER_H_
+#define FML_SHELL_COMMON_TASK_RUNNER_MERGER_H_
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/memory/ref_counted.h"
+#include "flutter/fml/message_loop_task_queues.h"
+
+namespace fml {
+
+class MessageLoopImpl;
+
+class TaskRunnerMerger : public fml::RefCountedThreadSafe<TaskRunnerMerger> {
+ public:
+  void MergeWithLease(size_t lease_term);
+
+  void ExtendLease(size_t lease_term);
+
+  void DecrementLease();
+
+  bool AreMerged() const;
+
+  TaskRunnerMerger(fml::TaskQueueId platform_queue_id,
+                   fml::TaskQueueId gpu_queue_id);
+
+  bool OnWrongThread();
+
+ private:
+  static const int kLeaseNotSet;
+  fml::TaskQueueId platform_queue_id_;
+  fml::TaskQueueId gpu_queue_id_;
+  fml::RefPtr<fml::MessageLoopTaskQueues> task_queues_;
+  std::atomic_int lease_term_;
+  bool is_merged_;
+
+  FML_FRIEND_REF_COUNTED_THREAD_SAFE(TaskRunnerMerger);
+  FML_FRIEND_MAKE_REF_COUNTED(TaskRunnerMerger);
+  FML_DISALLOW_COPY_AND_ASSIGN(TaskRunnerMerger);
+};
+
+}  // namespace fml
+
+#endif  // FML_SHELL_COMMON_TASK_RUNNER_MERGER_H_

--- a/fml/task_runner_merger.h
+++ b/fml/task_runner_merger.h
@@ -19,7 +19,8 @@ class TaskRunnerMerger : public fml::RefCountedThreadSafe<TaskRunnerMerger> {
 
   void ExtendLease(size_t lease_term);
 
-  void DecrementLease();
+  // Returns true if we unmerged this turn.
+  bool DecrementLease();
 
   bool AreMerged() const;
 

--- a/fml/task_runner_merger_unittests.cc
+++ b/fml/task_runner_merger_unittests.cc
@@ -1,0 +1,147 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define FML_USED_ON_EMBEDDER
+
+#include <atomic>
+#include <thread>
+
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/synchronization/count_down_latch.h"
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/fml/task_runner_merger.h"
+#include "gtest/gtest.h"
+
+TEST(TaskRunnerMerger, RemainMergedTillLeaseExpires) {
+  fml::MessageLoop* loop1 = nullptr;
+  fml::AutoResetWaitableEvent latch1;
+  fml::AutoResetWaitableEvent term1;
+  std::thread thread1([&loop1, &latch1, &term1]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop1 = &fml::MessageLoop::GetCurrent();
+    latch1.Signal();
+    term1.Wait();
+  });
+
+  fml::MessageLoop* loop2 = nullptr;
+  fml::AutoResetWaitableEvent latch2;
+  fml::AutoResetWaitableEvent term2;
+  std::thread thread2([&loop2, &latch2, &term2]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop2 = &fml::MessageLoop::GetCurrent();
+    latch2.Signal();
+    term2.Wait();
+  });
+
+  latch1.Wait();
+  latch2.Wait();
+
+  fml::TaskQueueId qid1 = loop1->GetTaskRunner()->GetTaskQueueId();
+  fml::TaskQueueId qid2 = loop2->GetTaskRunner()->GetTaskQueueId();
+  const auto task_runner_merger_ =
+      fml::MakeRefCounted<fml::TaskRunnerMerger>(qid1, qid2);
+  const int kNumFramesMerged = 5;
+
+  ASSERT_FALSE(task_runner_merger_->AreMerged());
+
+  task_runner_merger_->MergeWithLease(kNumFramesMerged);
+
+  for (int i = 0; i < kNumFramesMerged; i++) {
+    ASSERT_TRUE(task_runner_merger_->AreMerged());
+    task_runner_merger_->DecrementLease();
+  }
+
+  ASSERT_FALSE(task_runner_merger_->AreMerged());
+
+  term1.Signal();
+  term2.Signal();
+  thread1.join();
+  thread2.join();
+}
+
+TEST(TaskRunnerMerger, OnWrongThread) {
+  fml::MessageLoop* loop1 = nullptr;
+  fml::AutoResetWaitableEvent latch1;
+  std::thread thread1([&loop1, &latch1]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop1 = &fml::MessageLoop::GetCurrent();
+    loop1->GetTaskRunner()->PostTask([&]() { latch1.Signal(); });
+    loop1->Run();
+  });
+
+  fml::MessageLoop* loop2 = nullptr;
+  fml::AutoResetWaitableEvent latch2;
+  std::thread thread2([&loop2, &latch2]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop2 = &fml::MessageLoop::GetCurrent();
+    loop2->GetTaskRunner()->PostTask([&]() { latch2.Signal(); });
+    loop2->Run();
+  });
+
+  latch1.Wait();
+  latch2.Wait();
+
+  fml::TaskQueueId qid1 = loop1->GetTaskRunner()->GetTaskQueueId();
+  fml::TaskQueueId qid2 = loop2->GetTaskRunner()->GetTaskQueueId();
+  const auto task_runner_merger_ =
+      fml::MakeRefCounted<fml::TaskRunnerMerger>(qid1, qid2);
+
+  fml::CountDownLatch pre_merge(2), post_merge(2), post_unmerge(2);
+
+  loop1->GetTaskRunner()->PostTask([&]() {
+    ASSERT_TRUE(task_runner_merger_->OnWrongThread());
+    ASSERT_EQ(fml::MessageLoop::GetCurrentTaskQueueId(), qid1);
+    pre_merge.CountDown();
+  });
+
+  loop2->GetTaskRunner()->PostTask([&]() {
+    ASSERT_FALSE(task_runner_merger_->OnWrongThread());
+    ASSERT_EQ(fml::MessageLoop::GetCurrentTaskQueueId(), qid2);
+    pre_merge.CountDown();
+  });
+
+  pre_merge.Wait();
+
+  task_runner_merger_->MergeWithLease(1);
+
+  loop1->GetTaskRunner()->PostTask([&]() {
+    ASSERT_FALSE(task_runner_merger_->OnWrongThread());
+    ASSERT_EQ(fml::MessageLoop::GetCurrentTaskQueueId(), qid1);
+    post_merge.CountDown();
+  });
+
+  loop2->GetTaskRunner()->PostTask([&]() {
+    // this will be false since this is going to be run
+    // on loop1 really.
+    ASSERT_FALSE(task_runner_merger_->OnWrongThread());
+    ASSERT_EQ(fml::MessageLoop::GetCurrentTaskQueueId(), qid1);
+    post_merge.CountDown();
+  });
+
+  post_merge.Wait();
+
+  task_runner_merger_->DecrementLease();
+
+  loop1->GetTaskRunner()->PostTask([&]() {
+    ASSERT_TRUE(task_runner_merger_->OnWrongThread());
+    ASSERT_EQ(fml::MessageLoop::GetCurrentTaskQueueId(), qid1);
+    post_unmerge.CountDown();
+  });
+
+  loop2->GetTaskRunner()->PostTask([&]() {
+    ASSERT_FALSE(task_runner_merger_->OnWrongThread());
+    ASSERT_EQ(fml::MessageLoop::GetCurrentTaskQueueId(), qid2);
+    post_unmerge.CountDown();
+  });
+
+  post_unmerge.Wait();
+
+  loop1->GetTaskRunner()->PostTask([&]() { loop1->Terminate(); });
+
+  loop2->GetTaskRunner()->PostTask([&]() { loop2->Terminate(); });
+
+  thread1.join();
+  thread2.join();
+}

--- a/shell/common/pipeline.h
+++ b/shell/common/pipeline.h
@@ -138,6 +138,9 @@ class Pipeline : public fml::RefCountedThreadSafe<Pipeline<R>> {
 
     {
       std::scoped_lock lock(queue_mutex_);
+      if (queue_.empty()) {
+        return PipelineConsumeResult::NoneAvailable;
+      }
       std::tie(resource, trace_id) = std::move(queue_.front());
       queue_.pop_front();
       items_count = queue_.size();

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -14,6 +14,7 @@
 #include "flutter/fml/closure.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/fml/task_runner_merger.h"
 #include "flutter/lib/ui/snapshot_delegate.h"
 #include "flutter/shell/common/pipeline.h"
 #include "flutter/shell/common/surface.h"
@@ -102,12 +103,13 @@ class Rasterizer final : public SnapshotDelegate {
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
+  fml::RefPtr<fml::TaskRunnerMerger> task_runner_merger_;
 
   // |SnapshotDelegate|
   sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                     SkISize picture_size) override;
 
-  void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
+  RasterStatus DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 
   RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 


### PR DESCRIPTION
After pre-roll we know if there have been any mutations made to the IOS embedded UIViews. If there are any mutations and the thread configuration is such chat the mutations will be committed on an illegal thread (GPU thread), we merge the threads and keep them merged until the lease expires. The lease is currently set to expire after 10 frames of no mutations. If there are any mutations in the interim we extend the lease.

`TaskRunnerMerger` will ultimately be responsible for enforcing the correct thread configurations.

This configuration will be inactive even after this change since still use the same thread when we create the iOS engine. That is slated to change in the coming PRs.